### PR TITLE
Fix Medihounds having only 2 uses of Trauma kits, burn kits, and clot…

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules/station_vr.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/station_vr.dm
@@ -285,7 +285,7 @@
 	src.emag 	 = new /obj/item/weapon/dogborg/pounce(src) //Pounce
 	src.modules += new /obj/item/weapon/gripper/medical(src)//Now you can set up cyro or make peri. //CHOMPEdit
 
-	var/datum/matter_synth/medicine = new /datum/matter_synth/medicine(2000)
+	var/datum/matter_synth/medicine = new /datum/matter_synth/medicine(15000)  //CHOMPedit
 	synths += medicine
 
 	var/obj/item/stack/medical/advanced/clotting/C = new (src)


### PR DESCRIPTION
…ting kits.

This change fixes another one in  https://github.com/CHOMPStation2/CHOMPStation2/commit/954412a26a695100b426ce129c7cde77ae649eaf  that reduced Medihound's medical supplies seemingly unintentionally.